### PR TITLE
Added github repo to metadata

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Revision history for Perl extension Puzzle.
 
+0.05 2015-??-?? ESTRABD
+    - Dropped the check on $] >= 5.005 around ABSTRACT_FROM and AUTHOR
+      in Makefile.PL, since the first line is requiring Perl 5.014004.
+
 0.01  Tue Apr 28 15:03:31 2015
 	- original version; created by h2xs 1.23 with options
 		-A -n Puzzle

--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Perl extension Puzzle.
 
 0.05 2015-??-?? ESTRABD
+    - Added github repo to metadata
     - Dropped the check on $] >= 5.005 around ABSTRACT_FROM and AUTHOR
       in Makefile.PL, since the first line is requiring Perl 5.014004.
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -11,6 +11,16 @@ WriteMakefile(
     LIBS              => ['-lpuzzle'], # e.g., '-lm'
     DEFINE            => '', # e.g., '-DHAVE_SOMETHING'
     INC               => '', # e.g., '-I. -I/usr/include/other'
+    META_MERGE        => {
+        'meta-spec' => { version => 2 },
+        resources => {
+            repository  => {
+                type => 'git',
+                web  => 'https://github.com/estrabd/Image-Libpuzzle',
+                url  => 'https://github.com/estrabd/Image-Libpuzzle.git',
+            },
+        },
+    },
     # Un-comment this if you add C files to link with later:
     # OBJECT            => '$(O_FILES)', # link all the C files too
 );

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -6,9 +6,8 @@ WriteMakefile(
     NAME              => 'Image::Libpuzzle',
     VERSION_FROM      => 'lib/Image/Libpuzzle.pm', # finds $VERSION
     PREREQ_PM         => {}, # e.g., Module::Name => 1.1
-    ($] >= 5.005 ?     ## Add these new keywords supported since 5.005
-      (ABSTRACT_FROM  => 'lib/Image/Libpuzzle.pm', # retrieve abstract from module
-       AUTHOR         => 'B. Estrade <estrabd@gmail.com>') : ()),
+    ABSTRACT_FROM     => 'lib/Image/Libpuzzle.pm', # retrieve abstract from module
+    AUTHOR            => 'B. Estrade <estrabd@gmail.com>',
     LIBS              => ['-lpuzzle'], # e.g., '-lm'
     DEFINE            => '', # e.g., '-DHAVE_SOMETHING'
     INC               => '', # e.g., '-I. -I/usr/include/other'


### PR DESCRIPTION
Hi,

I noticed there was a github repo for this dist, so wanted to add it to the metadata.

In the Makefile.PL you require Perl 5.14.4, which means you can simplify the Makefile.PL, unless you plan to require an earlier version of Perl?

If you do require an earlier version of Perl, you'd need to do something like in [this Makefile.PL](https://metacpan.org/source/NEILB/Lingua-EN-Numbers-2.02/Makefile.PL).

Cheers,
Neil